### PR TITLE
[Fix] Apply tag version prefix consistently

### DIFF
--- a/commands/publish/lib/get-current-tags.js
+++ b/commands/publish/lib/get-current-tags.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const log = require("npmlog");
-const npa = require("npm-package-arg");
+// const npa = require("npm-package-arg");
 const childProcess = require("@lerna/child-process");
 
 module.exports.getCurrentTags = getCurrentTags;
@@ -25,11 +25,11 @@ function getCurrentTags(execOpts, matchingPattern) {
     .then((result) => {
       const lines = result.stdout.split("\n").filter(Boolean);
 
-      if (matchingPattern === "*@*") {
-        // independent mode does not respect tagVersionPrefix,
-        // but embeds the package name in the tag "prefix"
-        return lines.map((tag) => npa(tag).name);
-      }
+      // if (matchingPattern === "*@*") {
+      //   // independent mode does not respect tagVersionPrefix,
+      //   // but embeds the package name in the tag "prefix"
+      //   return lines.map((tag) => npa(tag).name);
+      // }
 
       // "fixed" mode can have a custom tagVersionPrefix,
       // but it doesn't really matter as it is not used to extract package names

--- a/commands/version/__tests__/version-conventional-commits.test.js
+++ b/commands/version/__tests__/version-conventional-commits.test.js
@@ -53,13 +53,13 @@ describe("--conventional-commits", () => {
         expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), "independent", {
           changelogPreset: undefined,
           rootPath: cwd,
-          tagPrefix: "v",
+          tagPrefix: "",
           prereleaseId: undefined,
         });
         expect(updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version }),
           "independent",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v", prereleaseId: undefined }
+          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "", prereleaseId: undefined }
         );
       });
     });
@@ -78,13 +78,13 @@ describe("--conventional-commits", () => {
         expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), "independent", {
           changelogPreset: undefined,
           rootPath: cwd,
-          tagPrefix: "v",
+          tagPrefix: "",
           prereleaseId,
         });
         expect(updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version }),
           "independent",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v" }
+          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "" }
         );
       });
     });
@@ -102,13 +102,13 @@ describe("--conventional-commits", () => {
         expect(recommendVersion).toHaveBeenCalledWith(expect.objectContaining({ name }), "independent", {
           changelogPreset: undefined,
           rootPath: cwd,
-          tagPrefix: "v",
+          tagPrefix: "",
           prerelease: undefined,
         });
         expect(updateChangelog).toHaveBeenCalledWith(
           expect.objectContaining({ name, version }),
           "independent",
-          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "v" }
+          { changelogPreset: undefined, rootPath: cwd, tagPrefix: "" }
         );
       });
     });
@@ -118,7 +118,7 @@ describe("--conventional-commits", () => {
       const changelogOpts = {
         changelogPreset: "foo-bar",
         rootPath: cwd,
-        tagPrefix: "v",
+        tagPrefix: "",
         prereleaseId: undefined,
       };
 

--- a/core/filter-options/lib/get-filtered-packages.js
+++ b/core/filter-options/lib/get-filtered-packages.js
@@ -61,6 +61,10 @@ function getFilteredPackages(packageGraph, execOpts, opts) {
       options.log.notice("filter", "including merged tags");
     }
 
+    if (options.tagVersionPrefix) {
+      options.log.notice("filter", "matching tags by prefix %s", options.tagVersionPrefix);
+    }
+
     chain = chain.then((/** @type {ReturnType<typeof filterPackages>} */ filteredPackages) =>
       Promise.resolve(collectUpdates(filteredPackages, packageGraph, execOpts, opts)).then((updates) => {
         const updated = new Set(updates.map(({ pkg }) => pkg.name));

--- a/utils/check-working-tree/README.md
+++ b/utils/check-working-tree/README.md
@@ -10,6 +10,7 @@ const { checkWorkingTree } = require("@lerna/check-working-tree");
 // values listed here are their defaults
 const options = {
   cwd: process.cwd(),
+  match: undefined,
 };
 
 (async () => {

--- a/utils/check-working-tree/lib/check-working-tree.js
+++ b/utils/check-working-tree/lib/check-working-tree.js
@@ -9,10 +9,10 @@ module.exports.mkThrowIfUncommitted = mkThrowIfUncommitted;
 module.exports.throwIfReleased = throwIfReleased;
 module.exports.throwIfUncommitted = mkThrowIfUncommitted();
 
-function checkWorkingTree({ cwd } = {}) {
+function checkWorkingTree({ cwd, match } = {}) {
   let chain = Promise.resolve();
 
-  chain = chain.then(() => describeRef({ cwd }));
+  chain = chain.then(() => describeRef({ cwd, match }));
 
   // wrap each test separately to allow all applicable errors to be reported
   const tests = [

--- a/utils/collect-updates/collect-updates.js
+++ b/utils/collect-updates/collect-updates.js
@@ -28,6 +28,7 @@ module.exports.getPackagesForOption = getPackagesForOption;
  * @property {boolean} [conventionalCommits]
  * @property {boolean} [conventionalGraduate]
  * @property {boolean} [excludeDependents]
+ * @property {string=} [tagVersionPrefix]
  */
 
 /**
@@ -38,7 +39,18 @@ module.exports.getPackagesForOption = getPackagesForOption;
  * @param {UpdateCollectorOptions} commandOptions
  */
 function collectUpdates(filteredPackages, packageGraph, execOpts, commandOptions) {
-  const { forcePublish, conventionalCommits, conventionalGraduate, excludeDependents } = commandOptions;
+  const {
+    forcePublish,
+    conventionalCommits,
+    conventionalGraduate,
+    excludeDependents,
+    tagVersionPrefix,
+  } = commandOptions;
+
+  if (tagVersionPrefix) {
+    // eslint-disable-next-line no-param-reassign
+    execOpts = { ...execOpts, match: `${tagVersionPrefix}**` };
+  }
 
   // If --conventional-commits and --conventional-graduate are both set, ignore --force-publish
   const useConventionalGraduate = conventionalCommits && conventionalGraduate;


### PR DESCRIPTION
_Upstream PR: https://github.com/lerna/lerna/pull/3151_

## Description
- Apply tag version prefix in independent mode in the same way it's applied in fixed mode
- Fix inconsistencies of tag version prefix when reading git tags
- Remove default tag version prefix in independent mode (to keep it backwards compatible)

## Motivation and Context
This resolves already reported issue https://github.com/lerna/lerna/issues/2056
And tried attempt to partially solve it https://github.com/lerna/lerna/pull/2601

## How Has This Been Tested?
All unit and integration tests are passing.
Tested on a private repo where 2 subsequent lerna calls were made with different tag version prefixes
and with this patch it managed to release 2 times as expected.
No new unit and integration tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
